### PR TITLE
Add ability to fetch from hiscores & update all discord roles.

### DIFF
--- a/.changeset/empty-zoos-train.md
+++ b/.changeset/empty-zoos-train.md
@@ -1,0 +1,5 @@
+---
+'@osrs-leagues/discord-bot': major
+---
+
+Add jobs & tasks for updating all discord user roles for the current league.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@changesets/cli": "^2.19.0",
     "@discordjs/builders": "^0.11.0",
     "@discordjs/rest": "^0.2.0-canary.0",
+    "axios": "^0.24.0",
     "discord-api-types": "^0.26.1",
     "discord.js": "^13.5.0",
     "dotenv": "^10.0.0",

--- a/src/discord/actions/index.ts
+++ b/src/discord/actions/index.ts
@@ -1,0 +1,3 @@
+import setLeagueRole from './setLeagueRole';
+
+export { setLeagueRole };

--- a/src/discord/commands/hiscores.ts
+++ b/src/discord/commands/hiscores.ts
@@ -1,0 +1,61 @@
+import {
+  SlashCommandBuilder,
+  SlashCommandStringOption,
+} from '@discordjs/builders';
+
+import { fetchHiscoreUser } from '../../tasks';
+import getHiscoreRankingMessage from '../messages/hiscoreRanking';
+import { Command } from './types';
+
+const channels = [
+  /**
+   * OSRS Leagues server
+   */
+  '769283619595485224', // #bot-commands
+  '636193036195463178', // #bot-commands-test
+
+  /**
+   * Bot Testing Server
+   */
+  '931963036896464946', // #bot-commands
+];
+
+const hiscoresCommand: Command = {
+  channels,
+  data: new SlashCommandBuilder()
+    .setName('hiscores')
+    .setDescription(
+      'Show the league points & rank of a user from the League hiscores.',
+    )
+    .addStringOption((option: SlashCommandStringOption) =>
+      option
+        .setName('username')
+        .setDescription('Enter a Shattered Relics League username.')
+        .setRequired(true),
+    ) as SlashCommandBuilder,
+  execute: async (interaction) => {
+    const username = interaction.options.getString('username');
+    if (!username) {
+      return interaction.reply('Please enter a valid username.');
+    }
+    try {
+      const hiscoreResult = await fetchHiscoreUser.execute({
+        username,
+      });
+      if (hiscoreResult) {
+        const message = getHiscoreRankingMessage({
+          username,
+          points: hiscoreResult.league_points,
+          rank: hiscoreResult.league_rank,
+        });
+        return interaction.reply({ embeds: [message] });
+      } else {
+        return interaction.reply('Unable to find user on hiscores.');
+      }
+    } catch (error) {
+      return interaction.reply('Unable to find user on hiscores.');
+    }
+  },
+};
+
+export default hiscoresCommand;

--- a/src/discord/commands/index.ts
+++ b/src/discord/commands/index.ts
@@ -3,6 +3,7 @@ import { Collection } from 'discord.js';
 import pingCommand from './ping';
 import fetchLeagueRanksCommand from './fetch_league_ranks';
 import hiscoresCommand from './hiscores';
+import leagueNameCommand from './league_name';
 import leagueRanksCommand from './league_ranks';
 import shatteredRelicsNameCommand from './shattered_relics_name';
 import trailblazerNameCommand from './trailblazer_name';
@@ -14,6 +15,7 @@ const commandData = [
   pingCommand,
   fetchLeagueRanksCommand,
   hiscoresCommand,
+  leagueNameCommand,
   leagueRanksCommand,
   shatteredRelicsNameCommand,
   trailblazerNameCommand,

--- a/src/discord/commands/index.ts
+++ b/src/discord/commands/index.ts
@@ -2,19 +2,23 @@ import { Collection } from 'discord.js';
 
 import pingCommand from './ping';
 import fetchLeagueRanksCommand from './fetch_league_ranks';
+import hiscoresCommand from './hiscores';
 import leagueRanksCommand from './league_ranks';
 import shatteredRelicsNameCommand from './shattered_relics_name';
 import trailblazerNameCommand from './trailblazer_name';
 import twistedNameCommand from './twisted_name';
+import updateAllRanksCommand from './update_all_ranks';
 import { Command } from './types';
 
 const commandData = [
   pingCommand,
   fetchLeagueRanksCommand,
+  hiscoresCommand,
   leagueRanksCommand,
   shatteredRelicsNameCommand,
   trailblazerNameCommand,
   twistedNameCommand,
+  updateAllRanksCommand,
 ];
 
 const commands = new Collection<string, Command>();

--- a/src/discord/commands/shattered_relics_name.ts
+++ b/src/discord/commands/shattered_relics_name.ts
@@ -39,10 +39,11 @@ const shatteredRelicsNameCommand: Command = {
         .setRequired(true),
     ) as SlashCommandBuilder,
   execute: async (interaction) => {
-    const username = interaction.options.getString('username');
+    let username = interaction.options.getString('username');
     if (!username) {
       return interaction.reply('Please enter a valid username.');
     }
+    username = username.toLocaleLowerCase();
     const discordMember = interaction.member;
     const result = await DiscordUser.upsert({
       user_id: discordMember.user.id,

--- a/src/discord/commands/shattered_relics_name.ts
+++ b/src/discord/commands/shattered_relics_name.ts
@@ -9,6 +9,7 @@ import { getRank, League } from '../../leagues';
 import setLeagueRole from '../actions/setLeagueRole';
 import getRankedMessage from '../messages/ranked';
 import getUnrankedMessage from '../messages/unranked';
+import { fetchHiscoreUser } from '../../tasks';
 import { Command } from './types';
 
 const channels = [
@@ -50,10 +51,13 @@ const shatteredRelicsNameCommand: Command = {
     const discordUser = result[0];
     if (discordUser) {
       const league: League = 'shattered_relics';
-      const leagueUser = await ShatteredRelicsLeague.findOne({
-        where: { name: username },
-      });
-      if (leagueUser) {
+      const hiscoreResults = await fetchHiscoreUser.execute({ username });
+      if (hiscoreResults) {
+        const leagueUserResult = await ShatteredRelicsLeague.upsert({
+          name: username,
+          points: hiscoreResults.league_points,
+        });
+        const leagueUser = leagueUserResult[0];
         const rank = getRank(leagueUser.points, league);
         const rankResult = await setLeagueRole({
           league,

--- a/src/discord/commands/trailblazer_name.ts
+++ b/src/discord/commands/trailblazer_name.ts
@@ -36,10 +36,11 @@ const trailblazerNameCommand: Command = {
         .setRequired(true),
     ) as SlashCommandBuilder,
   execute: async (interaction) => {
-    const username = interaction.options.getString('username');
+    let username = interaction.options.getString('username');
     if (!username) {
       return interaction.reply('Please enter a valid username.');
     }
+    username = username.toLocaleLowerCase();
     const discordMember = interaction.member;
     const result = await DiscordUser.upsert({
       user_id: discordMember.user.id,

--- a/src/discord/commands/twisted_name.ts
+++ b/src/discord/commands/twisted_name.ts
@@ -36,10 +36,11 @@ const twistedNameCommand: Command = {
         .setRequired(true),
     ) as SlashCommandBuilder,
   execute: async (interaction) => {
-    const username = interaction.options.getString('username');
+    let username = interaction.options.getString('username');
     if (!username) {
       return interaction.reply('Please enter a valid username.');
     }
+    username = username.toLocaleLowerCase();
     const discordMember = interaction.member;
     const result = await DiscordUser.upsert({
       user_id: discordMember.user.id,

--- a/src/discord/commands/update_all_ranks.ts
+++ b/src/discord/commands/update_all_ranks.ts
@@ -1,0 +1,46 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+
+import { updateDiscordRoles, updateLeagueUsers } from '../../tasks';
+import { Command } from './types';
+
+const roles = [
+  /**
+   * OSRS Leagues server
+   */
+  '636007821661569064', // Administrator
+
+  /**
+   * Bot testing server
+   */
+  '931999272738619473', // Tester
+];
+
+const channels = [
+  /**
+   * OSRS Leagues server
+   */
+  '636193036195463178', // #bot-commands-test
+  '763899863280648252', // #staff-casual
+  '931930206225178724', // #staff-admin
+
+  /**
+   * Bot testing server
+   */
+  '931963036896464946', // #bot-commands
+];
+
+const updateAllRanksCommand: Command = {
+  channels,
+  roles,
+  data: new SlashCommandBuilder()
+    .setName('update_all_ranks')
+    .setDescription('Update all user roles for Shattered Relics rankings.'),
+  execute: async (interaction) => {
+    await interaction.reply('Attempting to update all user roles!');
+    await updateLeagueUsers.execute();
+    const amountUpdated = await updateDiscordRoles.execute();
+    await interaction.reply(`Updated ${amountUpdated} discord user roles!`);
+  },
+};
+
+export default updateAllRanksCommand;

--- a/src/discord/commands/update_all_ranks.ts
+++ b/src/discord/commands/update_all_ranks.ts
@@ -39,7 +39,7 @@ const updateAllRanksCommand: Command = {
     await interaction.reply('Attempting to update all user roles!');
     await updateLeagueUsers.execute();
     const amountUpdated = await updateDiscordRoles.execute();
-    await interaction.reply(`Updated ${amountUpdated} discord user roles!`);
+    await interaction.editReply(`Updated ${amountUpdated} discord user roles!`);
   },
 };
 

--- a/src/discord/messages/hiscoreRanking.ts
+++ b/src/discord/messages/hiscoreRanking.ts
@@ -1,0 +1,40 @@
+import { MessageEmbed } from 'discord.js';
+
+import { encodeURL } from '../../utils/strings';
+
+import {
+  CURRENT_LEAGUE,
+  getLeagueName,
+  getRank,
+  getRankName,
+  League,
+} from '../../leagues';
+
+type HiscoreRankingMessageParams = {
+  league?: League;
+  points: number;
+  rank: number;
+  username: string;
+};
+
+const getHiscoreRankingMessage = ({
+  league = CURRENT_LEAGUE,
+  username,
+  points,
+  rank,
+}: HiscoreRankingMessageParams): MessageEmbed => {
+  const leagueRank = getRank(points, league);
+  const rankName = getRankName(leagueRank);
+  const leagueName = getLeagueName(league);
+  let body = '';
+  body += `League Points: ${points}\n`;
+  body += `Hiscores Rank Number: ${rank}\n`;
+  body += `League Rank: ${rankName}\n`;
+  return new MessageEmbed()
+    .setColor('#64d85b')
+    .setTitle(`${username} ${leagueName} League Stats:`)
+    .setDescription(body)
+    .setURL(encodeURL(`https://league.wiseoldman.net/players/${username}/`));
+};
+
+export default getHiscoreRankingMessage;

--- a/src/discord/messages/pointRankings.ts
+++ b/src/discord/messages/pointRankings.ts
@@ -26,7 +26,7 @@ const getPointRankingsMessage = (
   }
   return new MessageEmbed()
     .setColor('#64d85b')
-    .setTitle(`Current ${leagueName} point rankings:`)
+    .setTitle(`Current ${leagueName} League point rankings:`)
     .setDescription(body);
 };
 

--- a/src/discord/messages/ranked.ts
+++ b/src/discord/messages/ranked.ts
@@ -1,6 +1,7 @@
 import { Guild, MessageEmbed } from 'discord.js';
 
 import { getLeagueName, getRankName, League, Rank } from '../../leagues';
+import { encodeURL } from '../../utils/strings';
 
 type RankedMessageParams = {
   guild: Guild;
@@ -13,14 +14,17 @@ const getRankedMessage = (params: RankedMessageParams): MessageEmbed => {
   const { guild, league, rank, username } = params;
   const rankName = getRankName(rank);
   const leagueName = getLeagueName(league);
-  const emojiName = 'twisted_' + rankName.toLowerCase();
+  const emojiName = `${leagueName
+    .toLocaleLowerCase()
+    .replace(' ', '_')}_${rankName.toLocaleLowerCase()}`;
   const emoji = guild.client.emojis.cache.find((e) => e.name === emojiName);
   const emojiMessage = emoji ? '<:' + emojiName + ':' + emoji.id + '>' : '';
   return new MessageEmbed()
     .setColor('#64d85b')
     .setTitle(
-      `You have set your ${leagueName} username to __**${username}**__. You are ranked **${rankName}** ${emojiMessage}`,
-    );
+      `You have set your ${leagueName} League username to __**${username}**__. You are ranked **${rankName}** ${emojiMessage}`,
+    )
+    .setURL(encodeURL(`https://league.wiseoldman.net/players/${username}/`));
 };
 
 export default getRankedMessage;

--- a/src/discord/messages/unranked.ts
+++ b/src/discord/messages/unranked.ts
@@ -1,6 +1,7 @@
 import { MessageEmbed } from 'discord.js';
 
 import { getLeagueName, League } from '../../leagues';
+import { encodeURL } from '../../utils/strings';
 
 type UnrankedMessageParams = {
   league: League;
@@ -13,8 +14,9 @@ const getUnrankedMessage = (params: UnrankedMessageParams): MessageEmbed => {
   return new MessageEmbed()
     .setColor('#64d85b')
     .setTitle(
-      `You have set your ${leagueName} username to **${username}**. No ${leagueName} rank was found.`,
-    );
+      `You have set your ${leagueName} League username to **${username}**. No ${leagueName} rank was found.`,
+    )
+    .setURL(encodeURL(`https://league.wiseoldman.net/players/${username}/`));
 };
 
 export default getUnrankedMessage;

--- a/src/leagues.ts
+++ b/src/leagues.ts
@@ -47,9 +47,9 @@ const LeagueRankings: Leagues = {
 };
 
 const LeagueNames: { [key in League]: string } = {
-  twisted: 'Twisted League',
-  trailblazer: 'Trailblazer League',
-  shattered_relics: 'Shattered Relics League',
+  twisted: 'Twisted',
+  trailblazer: 'Trailblazer',
+  shattered_relics: 'Shattered Relics',
 };
 
 const RankNames: { [key in Rank]: string } = {

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -1,7 +1,10 @@
 import { Job } from './types';
 
 const jobs: Job[] = [
-  //leaguePointRankingsJob - Disabled until league hiscores are working.
+  /* Disabled until league starts
+  leaguePointRankingsJob,
+  updateUsersJob
+  */
 ];
 
 export const scheduleJobs = () => {

--- a/src/schedule/jobs/index.ts
+++ b/src/schedule/jobs/index.ts
@@ -1,3 +1,4 @@
 import leaguePointRankingsJob from './leaguePointRankings';
+import updateUsersJob from './updateUsers';
 
-export { leaguePointRankingsJob };
+export { leaguePointRankingsJob, updateUsersJob };

--- a/src/schedule/jobs/updateUsers.ts
+++ b/src/schedule/jobs/updateUsers.ts
@@ -1,0 +1,23 @@
+import cron from 'node-cron';
+
+import config from '../../config';
+import { updateDiscordRoles, updateLeagueUsers } from '../../tasks';
+import { Job } from '../types';
+
+const updateUsersJob: Job = {
+  interval: {
+    testing: undefined,
+    development: undefined, //'* * * * *',
+    stage: '* * *',
+    production: '* * *',
+  },
+  schedule: () => {
+    const interval = updateUsersJob.interval;
+    cron.schedule(interval[config.environment], async () => {
+      await updateLeagueUsers.execute();
+      await updateDiscordRoles.execute();
+    });
+  },
+};
+
+export default updateUsersJob;

--- a/src/tasks/fetchHiscoreUser.ts
+++ b/src/tasks/fetchHiscoreUser.ts
@@ -25,19 +25,23 @@ const fetchHiscoreUser: Task<
       console.error('Invalid username provided to fetchHiscoreUser task.');
       return undefined;
     }
-    const response = await axios({ url: HISCORE_PLAYER_URL + username });
-    if (response && response.status == 200 && response.data.length > 0) {
-      const stats = response.data.split('\n');
-      if (stats.length > 0) {
-        const league_stats = stats[LEAGUE_POINTS_INDEX].split(',');
-        const league_rank = league_stats[0];
-        const league_points = league_stats[1];
-        return {
-          league_rank,
-          league_points,
-        };
+    try {
+      const response = await axios({ url: HISCORE_PLAYER_URL + username });
+      if (response && response.status == 200 && response.data.length > 0) {
+        const stats = response.data.split('\n');
+        if (stats.length > 0) {
+          const league_stats = stats[LEAGUE_POINTS_INDEX].split(',');
+          const league_rank = league_stats[0];
+          const league_points = league_stats[1];
+          return {
+            league_rank,
+            league_points,
+          };
+        }
+      } else {
+        return undefined;
       }
-    } else {
+    } catch (error) {
       return undefined;
     }
   },

--- a/src/tasks/fetchHiscoreUser.ts
+++ b/src/tasks/fetchHiscoreUser.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+import { Task } from './types';
+
+type FetchLeagueUserParams = {
+  username: string;
+};
+
+type FetchLeagueUserResults = {
+  league_rank: number;
+  league_points: number;
+};
+
+const HISCORE_PLAYER_URL =
+  'https://services.runescape.com/m=hiscore_oldschool_seasonal/index_lite.ws?player=';
+
+const LEAGUE_POINTS_INDEX = 23;
+
+const fetchHiscoreUser: Task<
+  FetchLeagueUserParams,
+  FetchLeagueUserResults | undefined
+> = {
+  execute: async ({ username }) => {
+    if (!username) {
+      console.error('Invalid username provided to fetchHiscoreUser task.');
+      return undefined;
+    }
+    const response = await axios({ url: HISCORE_PLAYER_URL + username });
+    if (response && response.status == 200 && response.data.length > 0) {
+      const stats = response.data.split('\n');
+      if (stats.length > 0) {
+        const league_stats = stats[LEAGUE_POINTS_INDEX].split(',');
+        const league_rank = league_stats[0];
+        const league_points = league_stats[1];
+        return {
+          league_rank,
+          league_points,
+        };
+      }
+    } else {
+      return undefined;
+    }
+  },
+};
+
+export default fetchHiscoreUser;

--- a/src/tasks/fetchLeaguePointRankings.ts
+++ b/src/tasks/fetchLeaguePointRankings.ts
@@ -65,6 +65,7 @@ const fetchLeaguePointRankings: Task = {
     setLeagueStandings(pointRankings);
     await browser.close();
     console.timeEnd('league_standings');
+    return true;
   },
 };
 

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,5 +1,13 @@
 import fetchLeaguePointRankings from './fetchLeaguePointRankings';
+import fetchHiscoreUser from './fetchHiscoreUser';
+import updateDiscordRoles from './updateDiscordRoles';
+import updateLeagueUsers from './updateLeagueUsers';
 import { Task } from './types';
 
-export { fetchLeaguePointRankings };
+export {
+  fetchLeaguePointRankings,
+  fetchHiscoreUser,
+  updateDiscordRoles,
+  updateLeagueUsers,
+};
 export type { Task };

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -1,3 +1,3 @@
-export type Task = {
-  execute: () => void;
+export type Task<TParams = undefined, TResult = boolean> = {
+  execute: (params?: TParams) => Promise<TResult>;
 };

--- a/src/tasks/updateDiscordRoles.ts
+++ b/src/tasks/updateDiscordRoles.ts
@@ -1,0 +1,46 @@
+import { DiscordUser, ShatteredRelicsLeague } from '../database/models';
+import { Task } from '.';
+import { client } from '../discord';
+import { setLeagueRole } from '../discord/actions';
+import { CURRENT_LEAGUE, getRank } from '../leagues';
+import config from '../config';
+
+const updateDiscordRoles: Task<undefined, number> = {
+  execute: async () => {
+    console.log('Updating all discord roles to latest ranks...');
+    const guild = client.guilds.cache.get(config.guild_id);
+    if (guild) {
+      let amountUpdated = 0;
+      const discordUsers = await DiscordUser.findAll();
+      for (const discordUser of discordUsers) {
+        if (discordUser) {
+          const guildMember = guild.members.cache.get(discordUser.user_id);
+          if (guildMember) {
+            const leagueUser = await ShatteredRelicsLeague.findByPk(
+              discordUser.shattered_relics_name,
+            );
+            if (leagueUser) {
+              const rank = getRank(leagueUser.points, CURRENT_LEAGUE);
+              await setLeagueRole({
+                league: CURRENT_LEAGUE,
+                rank: rank,
+                member: guildMember,
+                guild: guild,
+              });
+              amountUpdated++;
+            }
+          }
+        }
+      }
+      console.log(
+        `Updated ${amountUpdated} discord user's Shattered Relic roles.`,
+      );
+      return amountUpdated;
+    } else {
+      console.error(`Unable to find guild: ${config.guild_id}`);
+      return 0;
+    }
+  },
+};
+
+export default updateDiscordRoles;

--- a/src/tasks/updateLeagueUsers.ts
+++ b/src/tasks/updateLeagueUsers.ts
@@ -1,0 +1,37 @@
+import { fetchHiscoreUser } from '.';
+import sequelize from '../database';
+import { ShatteredRelicsLeague } from '../database/models';
+import { Task } from './types';
+
+const updateLeagueUsers: Task = {
+  execute: async () => {
+    console.log(`Running league users update task...`);
+    const leagueUsers = await ShatteredRelicsLeague.findAll();
+    const updateTransaction = await sequelize.transaction();
+    for (const leagueUser of leagueUsers) {
+      if (leagueUser.name) {
+        try {
+          const hiscoreResult = await fetchHiscoreUser.execute({
+            username: leagueUser.name,
+          });
+          if (hiscoreResult) {
+            await ShatteredRelicsLeague.update(
+              { points: hiscoreResult.league_points },
+              {
+                where: { name: leagueUser.name },
+                transaction: updateTransaction,
+              },
+            );
+          }
+        } catch (error) {
+          // no user results
+        }
+      }
+    }
+    updateTransaction.commit();
+    console.log(`Updated ${leagueUsers.length} shattered relic league users.`);
+    return true;
+  },
+};
+
+export default updateLeagueUsers;

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,0 +1,3 @@
+export function encodeURL(url: string) {
+  return encodeURI(url.replace(/ /g, '_'));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,6 +1293,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
+
 babel-jest@^27.4.5:
   version "27.4.5"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.5.tgz#d38bd0be8ea71d8b97853a5fc9f76deeb095c709"
@@ -2353,6 +2360,11 @@ flatted@^3.1.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
+
+follow-redirects@^1.14.4:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Included in this PR:

- Task to fetch a league hiscore entry
- Task to update all saved shattered relic users from hiscores
- Task to update all saved discord user's shattered relic roles
- Job to update SR users & their discord roles.
- 'hiscores' command to help test first task from above.