### PR TITLE
Enable remote league name commands

### DIFF
--- a/.changeset/lazy-squids-lie.md
+++ b/.changeset/lazy-squids-lie.md
@@ -1,0 +1,5 @@
+---
+'@osrs-leagues/discord-bot': patch
+---
+
+Enable remote commands

--- a/src/discord/interactions/commands/index.ts
+++ b/src/discord/interactions/commands/index.ts
@@ -17,7 +17,7 @@ import leagueNameLocal from './leagueNameLocal';
 import { CURRENT_LEAGUE } from '../../../leagues';
 import regionCommand from './regions';
 import removeRegionRoleCommand from './remove_region_role';
-import leagueNameBronze from './leagueNameBronze';
+import leagueNameRemote from './leagueNameRemote';
 
 const commandData = [
   pingCommand,
@@ -27,8 +27,8 @@ const commandData = [
   leagueNameLocal('shattered_relics'),
   leagueNameLocal('trailblazer'),
   leagueNameLocal('twisted'),
-  //leagueNameRemote(CURRENT_LEAGUE),
-  leagueNameBronze(CURRENT_LEAGUE),
+  leagueNameRemote(CURRENT_LEAGUE),
+  //leagueNameBronze(CURRENT_LEAGUE),
   leagueRanksCommand,
   regionCommand,
   removeLeagueRolesCommand,

--- a/src/discord/interactions/commands/league_name.ts
+++ b/src/discord/interactions/commands/league_name.ts
@@ -6,7 +6,7 @@ import {
 import { Command } from './types';
 import { channelGroups } from '../../Channel';
 import { CURRENT_LEAGUE } from '../../../leagues';
-import leagueNameBronze from './leagueNameBronze';
+import leagueNameRemote from './leagueNameRemote';
 
 const leagueNameCommand: Command = {
   channels: channelGroups.BOT_COMMANDS,
@@ -21,7 +21,7 @@ const leagueNameCommand: Command = {
         .setDescription('Enter your username for the current & active league.')
         .setRequired(true),
     ) as SlashCommandBuilder,
-  execute: leagueNameBronze(CURRENT_LEAGUE).execute,
+  execute: leagueNameRemote(CURRENT_LEAGUE).execute,
 };
 
 export default leagueNameCommand;


### PR DESCRIPTION
**Description**
Enable remote hiscore fetching for `league_name` and `trailblazer_reloaded_name` commands.