### PR TITLE
Update turtle command to remove channel and role restrictions

### DIFF
--- a/.changeset/bright-dragons-scream.md
+++ b/.changeset/bright-dragons-scream.md
@@ -1,0 +1,5 @@
+---
+'@osrs-leagues/discord-bot': patch
+---
+
+Update turtle command permissions

--- a/src/discord/interactions/commands/__tests__/turtle.test.ts
+++ b/src/discord/interactions/commands/__tests__/turtle.test.ts
@@ -12,7 +12,6 @@ import addTurtleCommand from '../add_turtle';
 import turtleCommand from '../turtle';
 import turtleClogCommand from '../turtle_clog';
 import { channelGroups } from '../../../Channel';
-import Role from '../../../Role';
 
 describe('turtle', () => {
   describe('TURTLE_RARITY_WEIGHTS', () => {
@@ -253,16 +252,12 @@ describe('turtle', () => {
       expect(turtleClogCommand.data.name).toBe('turtle_clog');
     });
 
-    test('turtle command should be restricted to staff channels', () => {
-      expect(turtleCommand.channels).toEqual(channelGroups.STAFF);
+    test('turtle command should not restrict channels', () => {
+      expect(turtleCommand.channels).toBeUndefined();
     });
 
-    test('turtle command should require staff roles', () => {
-      expect(turtleCommand.roles).toEqual([
-        Role.Administrator,
-        Role.Moderator,
-        Role.Tester,
-      ]);
+    test('turtle command should not restrict roles', () => {
+      expect(turtleCommand.roles).toBeUndefined();
     });
 
     test('turtle command should have a 10 minute cooldown', () => {
@@ -270,22 +265,18 @@ describe('turtle', () => {
       expect(turtleCommand.cooldown.duration).toBe(10 * 60 * 1000);
     });
 
-    test('turtle command cooldown should exempt testing channels', () => {
+    test('turtle command cooldown should exempt turtle channels', () => {
       expect(turtleCommand.cooldown.exemptChannels).toEqual(
-        channelGroups.TESTING,
+        channelGroups.TURTLES,
       );
     });
 
-    test('turtle_clog command should be restricted to staff channels', () => {
-      expect(turtleClogCommand.channels).toEqual(channelGroups.STAFF);
+    test('turtle_clog command should not restrict channels', () => {
+      expect(turtleClogCommand.channels).toBeUndefined();
     });
 
-    test('turtle_clog command should require staff roles', () => {
-      expect(turtleClogCommand.roles).toEqual([
-        Role.Administrator,
-        Role.Moderator,
-        Role.Tester,
-      ]);
+    test('turtle_clog command should not restrict roles', () => {
+      expect(turtleClogCommand.roles).toBeUndefined();
     });
   });
 });

--- a/src/discord/interactions/commands/turtle.ts
+++ b/src/discord/interactions/commands/turtle.ts
@@ -2,7 +2,6 @@ import { SlashCommandBuilder } from '@discordjs/builders';
 
 import { Command } from './types';
 import { channelGroups } from '../../Channel';
-import Role from '../../Role';
 import {
   turtleCache,
   selectWeightedTurtle,
@@ -11,11 +10,9 @@ import {
 import getTurtleMessage from '../../messages/turtle';
 
 const turtleCommand: Command = {
-  channels: channelGroups.STAFF,
-  roles: [Role.Administrator, Role.Moderator, Role.Tester],
   cooldown: {
     duration: 10 * 60 * 1000,
-    exemptChannels: channelGroups.TESTING,
+    exemptChannels: channelGroups.TURTLES,
   },
   data: new SlashCommandBuilder()
     .setName('turtle')

--- a/src/discord/interactions/commands/turtle_clog.ts
+++ b/src/discord/interactions/commands/turtle_clog.ts
@@ -1,14 +1,10 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 
 import { Command } from './types';
-import { channelGroups } from '../../Channel';
-import Role from '../../Role';
 import { turtleCache, getCollectedTurtleIds } from '../../../turtles';
 import getTurtleLogMessage from '../../messages/turtleLog';
 
 const turtleClogCommand: Command = {
-  channels: channelGroups.STAFF,
-  roles: [Role.Administrator, Role.Moderator, Role.Tester],
   data: new SlashCommandBuilder()
     .setName('turtle_clog')
     .setDescription('View your turtle collection log.'),


### PR DESCRIPTION
**Description**
This pull request updates the permissions for the `turtle` and `turtle_clog` Discord commands to make them more accessible. The main changes remove previous restrictions that limited these commands to staff roles and staff channels, and adjust cooldown exemptions to better fit their intended use.

**Command Permissions Update:**

* The `turtle` and `turtle_clog` commands no longer restrict usage to staff channels or require staff roles, making them accessible to all users. [[1]](diffhunk://#diff-40d88f672be30fdbbca22d45714f866673a3c88c0432e8d10c2c035fa5369be3L14-R15) [[2]](diffhunk://#diff-656ee8fcab9637cb6be56f200b7c50e3ee39487ded952c1f7476d856ba161116L4-L11)

* The cooldown exemption for the `turtle` command has been updated to apply to `channelGroups.TURTLES` instead of `channelGroups.TESTING`, ensuring that cooldowns are only bypassed in the appropriate channels.

**Test Updates:**

* Unit tests for both commands have been updated to reflect the new, unrestricted permissions and the revised cooldown exemption logic.

**Changelog:**

* Added a changeset entry documenting the update to turtle command permissions.