### PR TITLE
Update league points index for fetchHiscoreUser task

### DIFF
--- a/.changeset/tough-crabs-develop.md
+++ b/.changeset/tough-crabs-develop.md
@@ -1,0 +1,5 @@
+---
+'@osrs-leagues/discord-bot': patch
+---
+
+Fix hiscore index for leagues points; Set update users job to 2 hours

--- a/src/discord/interactions/commands/index.ts
+++ b/src/discord/interactions/commands/index.ts
@@ -13,6 +13,7 @@ import leagueRanksCommand from './league_ranks';
 import removeLeagueRolesCommand from './remove_league_roles';
 import updateLeaguePointsCommand from './update_league_points';
 import updateAllRolesCommand from './update_all_roles';
+import updateLeagueUsersCommand from './update_league_users';
 import { Command } from './types';
 import leagueNameLocal from './leagueNameLocal';
 import leagueNameBronze from './leagueNameBronze';
@@ -85,6 +86,7 @@ const commandData = [
   unblockDmCommand,
   updateLeaguePointsCommand,
   updateAllRolesCommand,
+  updateLeagueUsersCommand,
   viewChallengeCommand,
 ];
 

--- a/src/discord/interactions/commands/update_league_users.ts
+++ b/src/discord/interactions/commands/update_league_users.ts
@@ -1,0 +1,23 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+
+import { Command } from './types';
+import { getLeagueName } from '../../../leagues';
+import { channelGroups } from '../../Channel';
+import Role from '../../Role';
+import { updateUsersJob } from '../../../schedule/jobs';
+
+const updateLeagueUsersCommand: Command = {
+  channels: channelGroups.STAFF,
+  roles: [Role.Administrator, Role.Tester],
+  data: new SlashCommandBuilder()
+    .setName('update_league_users')
+    .setDescription(
+      `Update all league user points for ${getLeagueName()} from hiscores.`,
+    ),
+  execute: async (interaction) => {
+    await interaction.reply('Attempting to update all league user points!');
+    updateUsersJob.execute();
+  },
+};
+
+export default updateLeagueUsersCommand;

--- a/src/schedule/jobs/updateUsers.ts
+++ b/src/schedule/jobs/updateUsers.ts
@@ -8,7 +8,7 @@ const updateUsersJob: Job = {
     test: undefined,
     development: undefined, //'* * * * *',
     stage: undefined, // '* * *',
-    production: '2 */6 * * *',
+    production: '2 */2 * * *',
   },
   runOnStart: false,
   execute: async () => {

--- a/src/tasks/fetchHiscoreUser.ts
+++ b/src/tasks/fetchHiscoreUser.ts
@@ -14,7 +14,7 @@ type FetchLeagueUserResults = {
 const HISCORE_PLAYER_URL =
   'https://services.runescape.com/m=hiscore_oldschool_seasonal/index_lite.ws?player=';
 
-const LEAGUE_POINTS_INDEX = 24;
+const LEAGUE_POINTS_INDEX = 26;
 
 const fetchHiscoreUser: Task<
   FetchLeagueUserParams,


### PR DESCRIPTION
**Description**
This pull request introduces a patch to the `@osrs-leagues/discord-bot` package, focusing on fixing the hiscore index for league points, updating the user points update job schedule, and adding a new staff command to trigger user updates manually. The most important changes are grouped below:

**Bug Fixes:**

* Corrected the hiscore index used to fetch league points from `24` to `26` in `fetchHiscoreUser`, ensuring accurate point retrieval.

**Features:**

* Added a new staff-only slash command `/update_league_users` to manually trigger the update of all league user points from hiscores, including command registration and implementation. [[1]](diffhunk://#diff-9a7cda528d0802b507d2cb7ac7ed9bfd72f182deaa401936a0de57277c74b14dR1-R23) [[2]](diffhunk://#diff-d7ae7e0a0a269732cccf317dc52ae1aa8e10844473a8df3734c3be56eb9a153aR16) [[3]](diffhunk://#diff-d7ae7e0a0a269732cccf317dc52ae1aa8e10844473a8df3734c3be56eb9a153aR89)

**Scheduling Improvements:**

* Changed the scheduled update interval for the user points update job in production from every 6 hours to every 2 hours, allowing for more frequent updates.

**Documentation:**

* Added a changeset describing the patch, including the hiscore index fix and the updated job schedule.